### PR TITLE
Fix: #129 downloading sometimes fails when colon in title

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -262,7 +262,7 @@ const downloadSingleBook = async (
                 .find((i) => i.key === "filename")
                 ?.value.split(".")[1] ?? "azw3";
 
-        const filename = `${book.title.replace(': ',' - ')}.${extension}`;
+        const filename = `${book.title.replace(/: /g, ' - ').replace(/"/g, '')}.${extension}`;
         const data = await response.arrayBuffer();
 
         const downloadsDir = path.join(__dirname, "../downloads");

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,7 +262,7 @@ const downloadSingleBook = async (
                 .find((i) => i.key === "filename")
                 ?.value.split(".")[1] ?? "azw3";
 
-        const filename = book.title + "." + extension;
+        const filename = `${book.title.replace(': ',' - ')}.${extension}`;
         const data = await response.arrayBuffer();
 
         const downloadsDir = path.join(__dirname, "../downloads");


### PR DESCRIPTION
See issue #129 

Downloading sometimes fails when there's a : in the title.

Some titles will download, but others fail.

| ████████████████████████████████████████ | Howling Dark: The Sun Eater: Book Two | 1121355/1132352
[Error: ENOENT: no such file or directory, open 'C:\dev\amazon-kindle-bulk-downloader\downloads\Howli{
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'C:\\dev\\amazon-kindle-bulk-downloader\\downloads\\Howling Dark: The Sun Eater: Book Two.azw'
}

The fix for this is replacing : with -. 