### PR TITLE
Match actual default `maxConcurrency` value to one shown in README

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -442,7 +442,7 @@ type Options = {
     })
     .option("maxConcurrency", {
       type: "number",
-      default: 25,
+      default: 10,
       description: "Maximum number of concurrent downloads",
     })
     .option("startFromOffset", {


### PR DESCRIPTION
I was surprised when the default `maxConcurrency` value of `10` listed in the README did not match the actual value of `25`.

Since I found that a lower concurrency number worked better for me (no errors with 5 concurrent vs 5 errors with 25 concurrent, out of ~130 downloads), it seems best that the value ends up being the lower of the two.

Thank you for your work.