### PR TITLE
Duplicate downloading checking + fix startFromOffset

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ I recommend using the env template found in the root of the repo to create and .
 
 The following CLI arguments are made available to customise the downloader to your needs
 
-| Argument            | Default Value                          | Description                                                                                                                      |
-| ------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `--baseUrl`         | N/A (Will be prompted if not provided) | Which Amazon base URL to use. Note, this MUST include www. in order to work properly                                             |
-| `--totalDownloads`  | 9999                                   | Total number of downloads to do                                                                                                  |
-| `--maxConcurrency`  | 10                                     | Maximum number of concurrent downloads                                                                                           |
-| `--startFromOffset` | 0                                      | Index offset to begin downloading from. Allows resuming of previous partially finished attempts.                                 |
-| `--manualAuth`      | false                                  | Allows user to manually login using the pupeteer UI instead of automatically using ENV vars. Use when auto login is not working. |
+| Argument              | Default Value                          | Description                                                                                                                      |
+| --------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `--baseUrl`           | N/A (Will be prompted if not provided) | Which Amazon base URL to use. Note, this MUST include www. in order to work properly                                             |
+| `--totalDownloads`    | Infinity                               | Total number of downloads to do                                                                                                  |
+| `--maxConcurrency`    | 10                                     | Maximum number of concurrent downloads                                                                                           |
+| `--startFromOffset`   | 0                                      | Index offset to begin downloading from. Allows resuming of previous partially finished attempts.                                 |
+| `--manualAuth`        | false                                  | Allows user to manually login using the pupeteer UI instead of automatically using ENV vars. Use when auto login is not working. |
+| `--duplicateHandling` | skip                                   | How to handle files of the same name/size on the filesystem. Options: skip, overwrite                                            |
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ I recommend using the env template found in the root of the repo to create and .
 
 The following CLI arguments are made available to customise the downloader to your needs
 
-| Argument            | Default Value                          | Description                                                                                                                                                                                                                                                      |
-| ------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--baseUrl`         | N/A (Will be prompted if not provided) | Which Amazon base URL to use. Note, this MUST include www. in order to work properly                                                                                                                                                                             |
-| `--totalDownloads`  | 9999                                   | Total number of downloads to do                                                                                                                                                                                                                                  |
-| `--maxConcurrency`  | 10                                     | Maximum number of concurrent downloads                                                                                                                                                                                                                           |
-| `--startFromOffset` | 0                                      | Index offset to begin downloading from. Allows resuming of previous failed attempts. Note this argument has [known issues](https://github.com/treetrum/amazon-kindle-bulk-downloader/issues/162#issuecomment-2669569874) and should probably be avoided for now. |
-| `--manualAuth`      | false                                  | Allows user to manually login using the pupeteer UI instead of automatically using ENV vars. Use when auto login is not working.                                                                                                                                 |
+| Argument            | Default Value                          | Description                                                                                                                      |
+| ------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `--baseUrl`         | N/A (Will be prompted if not provided) | Which Amazon base URL to use. Note, this MUST include www. in order to work properly                                             |
+| `--totalDownloads`  | 9999                                   | Total number of downloads to do                                                                                                  |
+| `--maxConcurrency`  | 10                                     | Maximum number of concurrent downloads                                                                                           |
+| `--startFromOffset` | 0                                      | Index offset to begin downloading from. Allows resuming of previous partially finished attempts.                                 |
+| `--manualAuth`      | false                                  | Allows user to manually login using the pupeteer UI instead of automatically using ENV vars. Use when auto login is not working. |
 
 ### Running
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ const getAllContentItems = async (auth: Auth, options: Options) => {
     logUpdate(`Found ${allItems.length} books so far...`);
 
     if (
-      !data.GetContentOwnershipData.hasMoreItems ||
+      data.GetContentOwnershipData.items.length < batchSize ||
       allItems.length >= options.totalDownloads
     ) {
       hasMore = false;


### PR DESCRIPTION
### Changes:

- Adds a simple check to see if a book has already been downloaded (by checking the local files existence + filesize) and if its already downloaded will abort the request to save time on reruns of the tool
- Fixes the behaviour of startFromOffset by offsetting the list of books we fetch instead of offsetting the individual book downloads
- Adds a new flag `--duplicateHandling` with options for either `skip` or `overwrite` to control the duplicate download check
- Updates the default for `--totalDownloads` to be `Infinity`
- Downloaded file names now include the unique amazon indentifier (ASIN) to hopefully prevent issues where different editions of the same book were being overwritten when they shared a file name. Should address #185 and #186 