### PR TITLE
Fix #205 by requesting extra GC from JavaScriptCore

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "generate-env": "op inject -i .env.template -o .env -f",
-    "start": "bun run src/index.ts",
+    "start": "bun run --smol src/index.ts",
     "lint": "eslint src/",
     "prettier": "prettier . --check",
     "build": "bun build --compile src/index.ts --outfile lib/kindle-downloader",


### PR DESCRIPTION
The `--smol` parameter asks for extra garbage-collection, fixing occasional out-of-memory errors for Kindle volumes w/ lots of images.