### PR TITLE
Add support for retrying failed downloads

### DIFF
--- a/src/ProgressBars.test.ts
+++ b/src/ProgressBars.test.ts
@@ -23,9 +23,7 @@ describe("ProgressBars", () => {
     bar.update(10, 5);
     expect(bar.total).toBe(10);
     expect(bar.progress).toBe(5);
-    expect(logUpdate).toBeCalledWith(
-      "███████████████░░░░░░░░░░░░░░░ | Test | 5/10"
-    );
+    expect(logUpdate).toBeCalledWith("██████████░░░░░░░░░░ | Test | 5/10");
   });
 
   test("Renders multiple progress bars", () => {
@@ -38,8 +36,8 @@ describe("ProgressBars", () => {
 
     expect(logUpdate).toHaveBeenLastCalledWith(
       [
-        "███████████████░░░░░░░░░░░░░░░ | First Bar | 5/10",
-        "█████████████████████░░░░░░░░░ | Second Bar | 14/20",
+        "██████████░░░░░░░░░░ | First Bar | 5/10",
+        "██████████████░░░░░░ | Second Bar | 14/20",
       ].join("\n")
     );
   });
@@ -51,9 +49,7 @@ describe("ProgressBars", () => {
     bar.update(10, -5);
     expect(bar.total).toBe(10);
     expect(bar.progress).toBe(0);
-    expect(logUpdate).toBeCalledWith(
-      "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | Test | 0/10"
-    );
+    expect(logUpdate).toBeCalledWith("░░░░░░░░░░░░░░░░░░░░ | Test | 0/10");
   });
 
   test("Clamps to a max of total progress", () => {
@@ -64,9 +60,7 @@ describe("ProgressBars", () => {
 
     expect(bar.total).toBe(10);
     expect(bar.progress).toBe(10);
-    expect(logUpdate).toBeCalledWith(
-      "██████████████████████████████ | Test | 10/10"
-    );
+    expect(logUpdate).toBeCalledWith("████████████████████ | Test | 10/10");
   });
 });
 

--- a/src/ProgressBars.ts
+++ b/src/ProgressBars.ts
@@ -2,7 +2,7 @@ import logUpdate from "log-update";
 
 export const createProgressBarString = (
   progress: number,
-  barLength: number = 30,
+  barLength: number = 20,
   completedCharacter: string = "█",
   remainingCharacter: string = "░"
 ): string => {
@@ -34,19 +34,25 @@ export class ProgressBars {
   create(content: string) {
     const item = new ProgressBar(this, content);
     this.items.push(item);
+    this.render();
     return item;
   }
 }
 
 class ProgressBar {
   private log: ProgressBars;
-  private content: string;
+  private content: string = "";
   private _total: number = 1;
   private _progress: number = 0;
 
   constructor(log: ProgressBars, text: string) {
     this.log = log;
     this.content = text;
+  }
+
+  setContent(content: string) {
+    this.content = content;
+    this.log.render();
   }
 
   set total(total: number) {


### PR DESCRIPTION
This PR adds support for retrying failed downloads.

- Will now retry an additional 2 times if a download fails
- Adds an exponentially growing delay between request to hopefully alleviate rate limiting issues (2s -> 4s -> 8s)
- Updates logging progress bars to give updates throughout the download process of retries, etc.
- Shrinks the progress bars from 30 to 20 characters wide.