### PR TITLE
Add skipBooksMatching cli arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ HUGE thanks to @keithzg in #145 for the investigation work done on this front.
 
 #### Crashes when encountering certain books
 
-If the program always crashes on a specific book, I recommend downloading that book manually and using the `--skipBooksMatching` to exclude that book from being downloaded. This may help with out of memory issues, etc.
+If the program always crashes on a specific book, I recommend using the `--skipBooksMatching` flag to exclude that book from being downloaded. This may help with out of memory issues, etc. You can then attempt to download the problematic book manually from the browser.
 
 Note, this flag can be provided multiple times to skip books matching one of any number of matching phrases.
 

--- a/README.md
+++ b/README.md
@@ -50,17 +50,18 @@ Note this tool is already configured to read environment variables from an `.env
 
 The following CLI arguments are made available to customise the downloader to your needs
 
-| Argument              | Default Value                          | Description                                                                                                                      |
-| --------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `--baseUrl`           | N/A (Will be prompted if not provided) | Which Amazon base URL to use. Note, this MUST include www. in order to work properly                                             |
-| `--totalDownloads`    | Infinity                               | Total number of downloads to do                                                                                                  |
-| `--maxConcurrency`    | 10                                     | Maximum number of concurrent downloads                                                                                           |
-| `--startFromOffset`   | 0                                      | Index offset to begin downloading from. Allows resuming of previous partially finished attempts.                                 |
-| `--manualAuth`        | false                                  | Allows user to manually login using the pupeteer UI instead of automatically using ENV vars. Use when auto login is not working. |
-| `--duplicateHandling` | skip                                   | How to handle files of the same name/size on the filesystem. Options: skip, overwrite                                            |
-| `--searchPhrase`      |                                        | Search phrase to filter books by                                                                                                 |
-| `--searchPhraseDirs`  | false                                  | If set to true, downloaded books will be saved to a sub-directory named after the search phrase within the downloadsDir          |
-| `--downloadsDir`      |                                        | Overrides the default downloads directory                                                                                        |
+| Argument              | Default Value                          | Description                                                                                                                                                                           |
+| --------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--baseUrl`           | N/A (Will be prompted if not provided) | Which Amazon base URL to use. Note, this MUST include www. in order to work properly                                                                                                  |
+| `--totalDownloads`    | Infinity                               | Total number of downloads to do                                                                                                                                                       |
+| `--maxConcurrency`    | 10                                     | Maximum number of concurrent downloads                                                                                                                                                |
+| `--startFromOffset`   | 0                                      | Index offset to begin downloading from. Allows resuming of previous partially finished attempts.                                                                                      |
+| `--manualAuth`        | false                                  | Allows user to manually login using the pupeteer UI instead of automatically using ENV vars. Use when auto login is not working.                                                      |
+| `--duplicateHandling` | skip                                   | How to handle files of the same name/size on the filesystem. Options: skip, overwrite                                                                                                 |
+| `--searchPhrase`      |                                        | Search phrase to filter books by                                                                                                                                                      |
+| `--searchPhraseDirs`  | false                                  | If set to true, downloaded books will be saved to a sub-directory named after the search phrase within the downloadsDir                                                               |
+| `--downloadsDir`      |                                        | Overrides the default downloads directory                                                                                                                                             |
+| `--skipBooksMatching` |                                        | If a book title contains this phrase, don't attempt to download it. Case sensitive. Useful for skipping books that crashes. Can be provided multiple times for multiple skip options. |
 
 ### Running
 
@@ -150,3 +151,23 @@ Whilst this tool doesn't explicitly require Node (Bun is an _alternative_), it s
 If you experience this, try upgrading your local Node version to >= v16 and see if that helps.
 
 HUGE thanks to @keithzg in #145 for the investigation work done on this front.
+
+#### Crashes when encountering certain books
+
+If the program always crashes on a specific book, I recommend downloading that book manually and using the `--skipBooksMatching` to exclude that book from being downloaded. This may help with out of memory issues, etc.
+
+Note, this flag can be provided multiple times to skip books matching one of any number of matching phrases.
+
+I.e. given a list of the following books:
+
+- The Lord of the Rings
+- The Hobbit
+- The Silmarillion
+
+If you provided the following skip arguments:
+
+```bash
+bun run start --skipBooksMatching "Hobbit" --skipBooksMatching "Silmarillion"
+```
+
+Only "The Lord of the Rings" would actually get downloaded.

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,6 +341,17 @@ const downloadSingleBook = async (
   const progressBar = progressBars.create(
     `Getting download url: ${safeFileName}`
   );
+
+  if (
+    options.skipBooksMatching &&
+    safeFileName.includes(options.skipBooksMatching)
+  ) {
+    progressBar.setContent(
+      `${Colors.yellow}Skipping: ${safeFileName}${Colors.reset}`
+    );
+    return;
+  }
+
   const downloadURL = await getDownloadUrl(auth, device, book, options);
 
   progressBar.setContent(`Downloading: ${safeFileName}`);
@@ -581,6 +592,11 @@ const sanitizeBaseURL = async (baseUrl: string | undefined) => {
     .option("downloadsDir", {
       type: "string",
       description: "Directory that downloaded books will be saved to",
+    })
+    .option("skipBooksMatching", {
+      type: "string",
+      description:
+        "If a book title contains this phrase, don't attempt to download it. Case sensitive. Useful for ignoring books causing issues.",
     })
     .parse();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -342,14 +342,16 @@ const downloadSingleBook = async (
     `Getting download url: ${safeFileName}`
   );
 
-  if (
-    options.skipBooksMatching &&
-    safeFileName.includes(options.skipBooksMatching)
-  ) {
-    progressBar.setContent(
-      `${Colors.yellow}Skipping: ${safeFileName}${Colors.reset}`
+  if (options.skipBooksMatching) {
+    const shouldSkip = options.skipBooksMatching.some((phrase) =>
+      safeFileName.includes(String(phrase))
     );
-    return;
+    if (shouldSkip) {
+      progressBar.setContent(
+        `${Colors.yellow}Skipping: ${safeFileName}${Colors.reset}`
+      );
+      return;
+    }
   }
 
   const downloadURL = await getDownloadUrl(auth, device, book, options);
@@ -594,13 +596,15 @@ const sanitizeBaseURL = async (baseUrl: string | undefined) => {
       description: "Directory that downloaded books will be saved to",
     })
     .option("skipBooksMatching", {
-      type: "string",
+      type: "array",
       description:
         "If a book title contains this phrase, don't attempt to download it. Case sensitive. Useful for ignoring books causing issues.",
     })
     .parse();
 
   const baseUrl = await sanitizeBaseURL(args.baseUrl);
+
+  args.skipBooksMatching;
 
   main({ ...args, baseUrl });
 })();

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,4 +13,5 @@ export type Options = {
   searchPhrase?: string;
   downloadsDir?: string;
   searchPhraseDirs: boolean;
+  skipBooksMatching?: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,5 +13,5 @@ export type Options = {
   searchPhrase?: string;
   downloadsDir?: string;
   searchPhraseDirs: boolean;
-  skipBooksMatching?: string;
+  skipBooksMatching?: (string | number)[];
 };


### PR DESCRIPTION
Adds a new cli argument --skipBooksMatching that allows the user to skip attempting to download books that contain a case-sensitive string in the title (I would suggest usage with the ASIN to ensure uniqueness).